### PR TITLE
adds support for .nvmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.npmrc
 /package.json
+/.nvmrc

--- a/drun
+++ b/drun
@@ -35,6 +35,12 @@ node_version_python() {
 node_version_ruby() {
   cat package.json | ruby -e 'require "json"; puts JSON[STDIN.read].fetch("engine",{}).fetch("node","latest")'
 }
+node_version_remote_lts() {
+  local LTS_NAME=$(echo "$1" | sed 's/^lts\///' | sed 's/^[*]$/./')
+  curl -sS https://nodejs.org/dist/index.tab \
+    | sed '1d' | cut -f'1,10' | grep -v '\t-' \
+    | grep -i "$LTS_NAME" | head -n1 | cut -f1 | sed 's/^v//'
+}
 node_version_raw_package_json() {
   if [ -r .nvmrc ]; then
     cat .nvmrc
@@ -44,12 +50,18 @@ node_version_raw_package_json() {
     node_version_jq 2> /dev/null || \
     node_version_python 2> /dev/null || \
     node_version_ruby 2> /dev/null || \
-    (echo >&2 'drun ERR! Failed to resolve node version. Defaulting to "latest"' && echo 'latest')
+    (echo >&2 'drun ERR! Failed to resolve node version from package.json. Defaulting to "latest"' && echo 'latest')
   fi
 }
 node_version_raw_any_source() {
   if [ -r .nvmrc ]; then
-    cat .nvmrc | sed 's/node/latest/'
+    local VERSION=$(cat .nvmrc | sed 's/node/latest/')
+    if echo "$VERSION" | grep -q 'lts'; then
+      node_version_remote_lts "$VERSION" || \
+        (echo >&2 'drun ERR! Failed to resolve node version from .nvmrc. Defaulting to "latest"' && echo 'latest')
+    else
+      echo "$VERSION"
+    fi
   else
     node_version_raw_package_json
   fi

--- a/drun
+++ b/drun
@@ -35,8 +35,10 @@ node_version_python() {
 node_version_ruby() {
   cat package.json | ruby -e 'require "json"; puts JSON[STDIN.read].fetch("engine",{}).fetch("node","latest")'
 }
-node_version_raw() {
-  if [ ! -f package.json ]; then
+node_version_raw_package_json() {
+  if [ -r .nvmrc ]; then
+    cat .nvmrc
+  elif [ ! -r package.json ]; then
     echo 'latest'
   else
     node_version_jq 2> /dev/null || \
@@ -45,8 +47,15 @@ node_version_raw() {
     (echo >&2 'drun ERR! Failed to resolve node version. Defaulting to "latest"' && echo 'latest')
   fi
 }
+node_version_raw_any_source() {
+  if [ -r .nvmrc ]; then
+    cat .nvmrc | sed 's/node/latest/'
+  else
+    node_version_raw_package_json
+  fi
+}
 node_version() {
-  node_version_raw | sed 's/^[<>=~^ ]*//'
+  node_version_raw_any_source | sed 's/^[<>=~^ ]*//'
 }
 
 CURRENT_DIR=$(pwd)

--- a/shippable.yml
+++ b/shippable.yml
@@ -19,6 +19,7 @@ build:
     - echo '{"engines":{"node":">=8.14.1"}}' > package.json && ./drun -xNA node --version | grep 'v8.14.1'
     - echo '{"engines":{"node":">= 8.14.1"}}' > package.json && ./drun -xNA node --version | grep 'v8.14.1'
     - echo '{"engines":{"node":"8.14.1"}}' > package.json && ./drun -xNM slim node --version | grep 'v8.14.1' # should read version from package.json node:...-slim image
+    - echo '10.16.0' > .nvmrc && ./drun -xNA node --version | grep 'v10.16.0' # should read version from .nvmrc
     - echo '{"test":"passing"}' | ./drun -x stedolan/jq '.test' | grep '"passing"' # should pipe into command inside container
     - echo '{"test":"passing"}' > test.json && ./drun -x stedolan/jq '.test' test.json | grep '"passing"' # should mount current directory
     - ./drun alpine sh -c 'apk update && apk add checkbashisms && checkbashisms -f drun && echo "checkbashisms passed."'

--- a/shippable.yml
+++ b/shippable.yml
@@ -13,6 +13,7 @@ build:
     - ./drun -x docker:17 sh -c './drun -x docker:17 sh -c "./drun -x docker:17 true"' # should do inception in 3 levels
     - ./drun -x mhart/alpine-node:5.12.0 node --version | grep 'v5.12.0' # should get version of node
     # should read version from package.json
+    - rm -f .nvmrc package.json
     - echo '{"engines":{"node":"8.14.1"}}' > package.json && ./drun -xNA node --version | grep 'v8.14.1'
     - echo '{"engines":{"node":"~8.14.1"}}' > package.json && ./drun -xNA node --version | grep 'v8.14.1'
     - echo '{"engines":{"node":"^8.14.1"}}' > package.json && ./drun -xNA node --version | grep 'v8.14.1'

--- a/shippable.yml
+++ b/shippable.yml
@@ -21,6 +21,7 @@ build:
     - echo '{"engines":{"node":">= 8.14.1"}}' > package.json && ./drun -xNA node --version | grep 'v8.14.1'
     - echo '{"engines":{"node":"8.14.1"}}' > package.json && ./drun -xNM slim node --version | grep 'v8.14.1' # should read version from package.json node:...-slim image
     - echo '10.16.0' > .nvmrc && ./drun -xNA node --version | grep 'v10.16.0' # should read version from .nvmrc
+    - echo 'lts/carbon' > .nvmrc && ./drun -xNA node --version | grep 'v8.16.0' # should read version from .nvmrc and resolve
     - echo '{"test":"passing"}' | ./drun -x stedolan/jq '.test' | grep '"passing"' # should pipe into command inside container
     - echo '{"test":"passing"}' > test.json && ./drun -x stedolan/jq '.test' test.json | grep '"passing"' # should mount current directory
     - ./drun alpine sh -c 'apk update && apk add checkbashisms && checkbashisms -f drun && echo "checkbashisms passed."'


### PR DESCRIPTION
- node version written to `.nvmrc` overrides any version in package.json
- resolve `lts/${LTS_NAME}` versions by querying https://nodejs.org/dist/index.tab. See current LTS versions at https://github.com/nodejs/Release#release-schedule